### PR TITLE
Fixed a bug on low-end devices when deploying multiples times

### DIFF
--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -697,6 +697,9 @@ export class RokuDeploy {
     public async deleteInstalledChannel(options?: RokuDeployOptions) {
         options = this.getOptions(options);
         
+        // Leave channel if it is running. Deleting when a channel is still running might
+        // cause a crash
+        // Issue: https://github.com/rokucommunity/roku-deploy/issues/41
         await this.pressHomeButton(options.host);
 
         let deleteOptions = this.generateBaseRequestOptions('plugin_install', options);

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -19,7 +19,7 @@ export class RokuDeploy {
     public request = request;
     public fsExtra = _fsExtra;
 
-    pressHomeKeyWaitIntervalInMillis = 3000;
+    pressHomeButtonWaitIntervalInMillis = 5000;
 
     /**
      * Copies all of the referenced files to the staging folder
@@ -433,7 +433,7 @@ export class RokuDeploy {
         }, false);
 
         // Wait for device to possibly leave current application or screensaver
-        util.sleep(this.pressHomeKeyWaitIntervalInMillis);
+        await util.sleep(this.pressHomeButtonWaitIntervalInMillis);
 
         return result;
     }
@@ -487,6 +487,7 @@ export class RokuDeploy {
                 await this.fsExtra.remove(zipFilePath);
             }
         }
+
     }
 
     /**
@@ -710,7 +711,6 @@ export class RokuDeploy {
 
         let results = await this.doPostRequest(deleteOptions);
         if (results.body.indexOf('Delete Failed: No such file') === -1 && results.body.indexOf('Uninstall Success') === -1) {
-            console.log(results.body);
             throw new errors.FailedDeviceResponseError('Failed to delete current installed channel');
         }
     }
@@ -733,7 +733,6 @@ export class RokuDeploy {
 
         let results = await this.doPostRequest(deleteOptions);
         if (results.body.indexOf('Delete Succeeded') === -1) {
-            console.log(results.body);
             throw new errors.FailedDeviceResponseError('Failed to delete current installed channel');
         }
     }

--- a/src/device.spec.ts
+++ b/src/device.spec.ts
@@ -58,6 +58,29 @@ describe('device', function device() {
         });
     });
 
+    describe('deleteInstalledChannel', () => {
+        it('works', async () => {
+            try {
+                // Deletes the current installed channel
+                await rokuDeploy.deleteInstalledChannel(options);
+                // Run again to make sure it doesn't fail when the channel is already deleted
+                await rokuDeploy.deleteInstalledChannel(options);
+            } catch (e) {
+                assert.fail(e.message);
+            }
+        });
+    });
+
+    describe('rekeyDevice', () => {
+        it('works', async () => {
+            try {
+                await rokuDeploy.rekeyDevice(options);
+            } catch (e) {
+                assert.fail(e.message);
+            }
+        });
+    });
+
     describe('deployAndSignPackage', () => {
         it('works', async () => {
             expect(file(await rokuDeploy.deployAndSignPackage(options))).to.exist;


### PR DESCRIPTION
- Added sleep interval to pressHomeKey to wait for device to leave
  current app or screensaver.
- Added pressHomeKey call before uninstalling a channel. Some devices
  might crash when delete is called and the device didn't finish loading
  the channel.
- Added deleteSignedPackage to delete the current signed package in the
  target device.
- Added call to deleteSignedPackage inside signExistingPackage to
  prevent any failed attempt of downloading a wrong package